### PR TITLE
Posts render on page refresh

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -1,5 +1,6 @@
 import { PostList } from "../scripts/feed/PostList.js";
 
+const applicationElement = document.querySelector(".giffygram");
 export const GiffyGram = () => {
   // Show main main UI
   return `<h1>Giffygram</h1>

--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -17,9 +17,11 @@ const applicationState = {
 };
 
 export const fetchUsers = () => {
+  
   return fetch(`${apiURL}/users`)
     .then((res) => res.json())
     .then((usersResponse) => {
+console.log("users return from api")
       applicationState.users = usersResponse;
     });
 };
@@ -29,9 +31,11 @@ export const getUsers = () => {
 };
 
 export const fetchPosts = () => {
+
   return fetch(`${apiURL}/posts`)
     .then((res) => res.json())
     .then((postResponse) => {
+      console.log("users return post from api")
       applicationState.posts = postResponse;
     });
 };

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -9,15 +9,15 @@ export const PostList = () => {
   `;
 
   for (const post of posts) {
-    return (html += `
+  html += `
       <div class="post">  
-    ${post.title}
+    <h3>${post.title}</h3> 
       <img class="postImage" src="${post.URL}" alt="A very cool turtle team" />
-      ${post.description}
+      <p>${post.description}<p>
       </div>
-    `);
+    ` 
   }
 
-  console.log(JSON.stringify(posts));
+  
   return html;
 };

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,6 +7,11 @@ const applicationElement = document.querySelector(".giffygram");
 export const renderApp = () => {
   fetchUsers()
     .then(() => {
+      return fetchPosts();
+    })
+    .then(() => {
+
+      console.log("rendering html")
       const user = parseInt(localStorage.getItem("gg_user"));
 
       if (user) {
@@ -14,8 +19,7 @@ export const renderApp = () => {
       } else {
         applicationElement.innerHTML = LoginForm();
       }
-    })
-    .then(fetchPosts());
+    });
 };
 
 applicationElement.addEventListener("stateChanged", () => {


### PR DESCRIPTION
co-author-by gabe gonzales <gq.gonzales1@gmail.com>
co-author-by dakota <dakotalambertbiz@gmail.com>

#### Changes Made

1. Modified file `rednerApp` on `Main.js to include `fetchPosts:` posts now successfully on refresh, rather than displaying an empty postList element.
   ​

#### Steps to Review

1. Checkout this branch locally.
   ```
   git fetch --all
   git checkout RS-Renderpost
   ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.

- Log in as your favorite instructor.
- Refresh page using browser tools: verify post list renders AGAIN.
   
4. View code file.
   > Confirm file modifications are present as indicated above.
   > Confirm no unused code or extraneous comments exist.
